### PR TITLE
App should also take SYMFONY_ENV variable, to check for SF environment.

### DIFF
--- a/web/.htaccess
+++ b/web/.htaccess
@@ -5,7 +5,7 @@
 # to each configured DirectoryIndex file (e.g. index.php, index.html, index.pl).
 DirectoryIndex website.php
 
-SetEnv APP_ENV dev
+SetEnv SYMFONY_ENV dev
 
 <IfModule mod_rewrite.c>
     RewriteEngine On

--- a/web/admin.php
+++ b/web/admin.php
@@ -10,7 +10,8 @@ defined('SYMFONY_DEBUG') || define('SYMFONY_DEBUG', getenv('SYMFONY_DEBUG') ?: S
 
 $loader = require_once __DIR__ . '/../app/bootstrap.php.cache';
 
-if (SYMFONY_ENV == 'dev') {
+// true has to be string, because we receive string from getenv
+if (SYMFONY_DEBUG == 'true') {
     Debug::enable();
 }
 

--- a/web/admin.php
+++ b/web/admin.php
@@ -6,12 +6,12 @@ use Symfony\Component\Debug\Debug;
 
 // Define application environment
 defined('SYMFONY_ENV') || define('SYMFONY_ENV', getenv('SYMFONY_ENV') ?: 'prod');
-defined('SYMFONY_DEBUG') || define('SYMFONY_DEBUG', getenv('SYMFONY_DEBUG') ?: SYMFONY_ENV === 'dev');
+defined('SYMFONY_DEBUG') ||
+    define('SYMFONY_DEBUG', filter_var(getenv('SYMFONY_DEBUG') ?: SYMFONY_ENV === 'dev', FILTER_VALIDATE_BOOLEAN));
 
 $loader = require_once __DIR__ . '/../app/bootstrap.php.cache';
 
-// true has to be string, because we receive string from getenv
-if (SYMFONY_DEBUG == 'true') {
+if (SYMFONY_DEBUG) {
     Debug::enable();
 }
 

--- a/web/admin.php
+++ b/web/admin.php
@@ -5,7 +5,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Debug\Debug;
 
 // Define application environment
-defined('APP_ENV') || define('APP_ENV', (getenv('APP_ENV') ? getenv('APP_ENV') : 'prod'));
+defined('APP_ENV') || define('APP_ENV', (getenv('APP_ENV') ?: (getenv('SYMFONY_ENV') ?: 'prod')));
 
 $loader = require_once __DIR__ . '/../app/bootstrap.php.cache';
 

--- a/web/admin.php
+++ b/web/admin.php
@@ -5,11 +5,12 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Debug\Debug;
 
 // Define application environment
-defined('APP_ENV') || define('APP_ENV', (getenv('APP_ENV') ?: (getenv('SYMFONY_ENV') ?: 'prod')));
+defined('SYMFONY_ENV') || define('SYMFONY_ENV', getenv('SYMFONY_ENV') ?: 'prod');
+defined('SYMFONY_DEBUG') || define('SYMFONY_DEBUG', getenv('SYMFONY_DEBUG') ?: SYMFONY_ENV === 'dev');
 
 $loader = require_once __DIR__ . '/../app/bootstrap.php.cache';
 
-if (APP_ENV == 'dev') {
+if (SYMFONY_ENV == 'dev') {
     Debug::enable();
 }
 
@@ -24,7 +25,7 @@ $apcLoader->register(true);
 
 require_once __DIR__ . '/../app/AdminKernel.php';
 
-$kernel = new AdminKernel(APP_ENV, (APP_ENV == 'dev') ? true : false);
+$kernel = new AdminKernel(SYMFONY_ENV, SYMFONY_DEBUG);
 $kernel->loadClassCache();
 $request = Request::createFromGlobals();
 $response = $kernel->handle($request);

--- a/web/website.php
+++ b/web/website.php
@@ -5,11 +5,12 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Debug\Debug;
 
 // Define application environment
-defined('APP_ENV') || define('APP_ENV', (getenv('APP_ENV') ?: (getenv('SYMFONY_ENV') ?: 'prod')));
+defined('SYMFONY_ENV') || define('SYMFONY_ENV', getenv('SYMFONY_ENV') ?: 'prod');
+defined('SYMFONY_DEBUG') || define('SYMFONY_DEBUG', getenv('SYMFONY_DEBUG') ?: SYMFONY_ENV === 'dev');
 
 $loader = require_once __DIR__ . '/../app/bootstrap.php.cache';
 
-if (APP_ENV == 'dev') {
+if (SYMFONY_ENV == 'dev') {
     Debug::enable();
 }
 
@@ -24,10 +25,10 @@ $apcLoader->register(true);
 
 require_once __DIR__ . '/../app/WebsiteKernel.php';
 
-$kernel = new WebsiteKernel(APP_ENV, (APP_ENV == 'dev') ? true : false);
+$kernel = new WebsiteKernel(SYMFONY_ENV, SYMFONY_DEBUG);
 $kernel->loadClassCache();
 
-if (APP_ENV != 'dev') {
+if (SYMFONY_ENV != 'dev') {
     require_once __DIR__ . '/../app/WebsiteCache.php';
     $kernel = new WebsiteCache($kernel);
 }

--- a/web/website.php
+++ b/web/website.php
@@ -10,7 +10,8 @@ defined('SYMFONY_DEBUG') || define('SYMFONY_DEBUG', getenv('SYMFONY_DEBUG') ?: S
 
 $loader = require_once __DIR__ . '/../app/bootstrap.php.cache';
 
-if (SYMFONY_ENV == 'dev') {
+// true has to be string, because we receive string from getenv
+if (SYMFONY_DEBUG == 'true') {
     Debug::enable();
 }
 

--- a/web/website.php
+++ b/web/website.php
@@ -6,12 +6,12 @@ use Symfony\Component\Debug\Debug;
 
 // Define application environment
 defined('SYMFONY_ENV') || define('SYMFONY_ENV', getenv('SYMFONY_ENV') ?: 'prod');
-defined('SYMFONY_DEBUG') || define('SYMFONY_DEBUG', getenv('SYMFONY_DEBUG') ?: SYMFONY_ENV === 'dev');
+defined('SYMFONY_DEBUG') ||
+    define('SYMFONY_DEBUG', filter_var(getenv('SYMFONY_DEBUG') ?: SYMFONY_ENV === 'dev', FILTER_VALIDATE_BOOLEAN));
 
 $loader = require_once __DIR__ . '/../app/bootstrap.php.cache';
 
-// true has to be string, because we receive string from getenv
-if (SYMFONY_DEBUG == 'true') {
+if (SYMFONY_DEBUG) {
     Debug::enable();
 }
 

--- a/web/website.php
+++ b/web/website.php
@@ -5,7 +5,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Debug\Debug;
 
 // Define application environment
-defined('APP_ENV') || define('APP_ENV', (getenv('APP_ENV') ? getenv('APP_ENV') : 'prod'));
+defined('APP_ENV') || define('APP_ENV', (getenv('APP_ENV') ?: (getenv('SYMFONY_ENV') ?: 'prod')));
 
 $loader = require_once __DIR__ . '/../app/bootstrap.php.cache';
 


### PR DESCRIPTION
I think we should use SYMFONY_ENV variable for checking the SF environment, since Symfony already works with it. If you check `console` file, we can see, that there it uses this one and not APP_ENV. For BC I left APP_ENV to be checked first, if this one is not present, try with SYMFONY_ENV.

|       Q         |                        A                         |
| -------------- |:------------------------------------------------|
| Tests pass? | none |
| Fixed tickets  | none                                     |
| BC Breaks    | none                              |
| Doc    | none                              |
